### PR TITLE
Create http module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 os:
   - linux
-  - osx
+  # - osx
 rust:
   - stable
   - nightly

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+use http::HttpServerConfig;
+
+pub struct Config {
+    source_path: Option<PathBuf>,
+    // udp_servers: Vec<UdpServerConfig>,
+    // tcp_servers: Vec<TcpServerConfig>,
+    http_servers: Vec<HttpServerConfig>,
+    // https_servers: Vec<HttpsServerConfig>,
+    // http2_servers: Vec<Http2ServerConfig>,
+}
+
+impl Config {
+    pub fn from_path<P>(path: P) -> Self
+    where
+        P: Into<PathBuf>,
+    {
+        let path = path.into();
+
+        // TODO: this is where we will generate all of the config instances
+
+        Self {
+            source_path: Some(path),
+            http_servers: Vec::new(),
+        }
+    }
+}

--- a/src/lib/http/config.rs
+++ b/src/lib/http/config.rs
@@ -1,0 +1,2 @@
+
+pub struct HttpServerConfig {}

--- a/src/lib/http/mod.rs
+++ b/src/lib/http/mod.rs
@@ -1,0 +1,3 @@
+mod config;
+
+pub use self::config::HttpServerConfig;

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,3 +1,6 @@
+mod config;
 mod proxy;
+mod http;
 
+pub use config::Config;
 pub use proxy::Proxy;

--- a/src/lib/proxy.rs
+++ b/src/lib/proxy.rs
@@ -1,25 +1,26 @@
+use config::Config;
 use std::path::PathBuf;
 
 pub struct Proxy {
-    config_path: Option<PathBuf>,
+    config: Option<Config>,
 }
 
 impl Proxy {
     pub fn new() -> Self {
-        Self { config_path: None }
+        Self { config: None }
     }
 
     pub fn load_config<P>(&mut self, config_path: P)
     where
         P: Into<PathBuf>,
     {
-        self.config_path = Some(config_path.into());
+        self.config = Some(Config::from_path(config_path));
         // TODO: here we will want to call instance methods on Proxy in order to configure the
         // instance.
     }
 
-    pub fn config_path(&self) -> Option<&PathBuf> {
-        self.config_path.as_ref()
+    pub fn config(&self) -> Option<&Config> {
+        self.config.as_ref()
     }
 
     pub fn run(&mut self) {
@@ -49,6 +50,6 @@ mod tests {
         let mut proxy = Proxy::new();
 
         proxy.load_config("my_config");
-        let _: &PathBuf = proxy.config_path().unwrap();
+        let _: &Config = proxy.config().unwrap();
     }
 }


### PR DESCRIPTION
This module will contain logic for building HTTP proxy servers and their filters.

This PR also introduces a Config struct. This struct contains a path (if loaded from disk), and a vector to contain HTTP proxy server configs from which the HTTP proxy server could be built from. 

I think it would be nice to also have servers for filtering TCP, UDP, etc so I've added the vectors for these commented out. When we add filters to these configs I think it would be good to we able to chain these filters. TCP filters could be passed as part of an HTTP config or a TCP config for example.